### PR TITLE
fixes #2: enhance error reporting and chunk returned file

### DIFF
--- a/islandora_bagit_extension.module
+++ b/islandora_bagit_extension.module
@@ -83,10 +83,19 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
   }
 
   if ( empty($checkSum) || empty($fileSize) ) {
+
     watchdog('bagit', 'BagIt Bag not created for !object: server error.',
       array('!object' => $object_to_bag_pid));
     http_response_code(500);
+
   } else {
+
+    // disable cache to save memery for 5GB files
+    drupal_page_is_cacheable(FALSE);
+    if (ob_get_level()) {
+      ob_end_clean();
+    }
+
     // Send Headers
     header('Content-Type: application/zip');
     header('Content-Disposition: attachment; filename="' . drupal_basename($filePath) . '"');
@@ -98,8 +107,16 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
     header('Accept-Ranges: bytes');
     header('Content-Length: ' . $fileSize);
 
-    readfile($filePath);
-  }
+    // Transfer file in 1024 byte chunks to save memory usage.
+    if ($fd = fopen($filePath, 'rb')) {
+      while (!feof($fd)) {
+        print fread($fd, 1024);
+      }
+      fclose($fd);
+    }
+    else {
+      http_response_code(404);
+    }
 
   // Clean up the temp directory where we downloaded the datastreams.
   if (file_exists($filePath)) {

--- a/islandora_bagit_extension.module
+++ b/islandora_bagit_extension.module
@@ -77,24 +77,29 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
     $fileSize = filesize($filePath);
   }
   catch (Exception $e) {
-    drush_print("Sorry, Islandora cannot create the Bag: " . $e->getMessage());
     watchdog('bagit', 'BagIt Bag not created for !object: !mess.',
-      array('!object' => $islandora_object->id, '!mess' => $e->getMessage()));
+      array('!object' => $object_to_bag_pid, '!mess' => $e->getMessage()));
     http_response_code(404);
   }
 
-  // Send Headers
-  header('Content-Type: application/zip');
-  header('Content-Disposition: attachment; filename="' . drupal_basename($filePath) . '"');
-  header('Content-Transfer-Encoding: binary');
-  header('ETag: "' . $checkSum . '"');
-  header('CWRC-MODIFIED-DATE: "' . $islandora_object->lastModifiedDate . '"');
-  header('CWRC-CHECKSUM: "' . $checkSum . '"');
-  header('CWRC-PID: "' . $object_to_bag_pid . '"');
-  header('Accept-Ranges: bytes');
-  header('Content-Length: ' . $fileSize);
+  if ( empty($checkSum) || empty($fileSize) ) {
+    watchdog('bagit', 'BagIt Bag not created for !object: server error.',
+      array('!object' => $object_to_bag_pid));
+    http_response_code(500);
+  } else {
+    // Send Headers
+    header('Content-Type: application/zip');
+    header('Content-Disposition: attachment; filename="' . drupal_basename($filePath) . '"');
+    header('Content-Transfer-Encoding: binary');
+    header('ETag: "' . $checkSum . '"');
+    header('CWRC-MODIFIED-DATE: "' . $islandora_object->lastModifiedDate . '"');
+    header('CWRC-CHECKSUM: "' . $checkSum . '"');
+    header('CWRC-PID: "' . $object_to_bag_pid . '"');
+    header('Accept-Ranges: bytes');
+    header('Content-Length: ' . $fileSize);
 
-  readfile($filePath);
+    readfile($filePath);
+  }
 
   // Clean up the temp directory where we downloaded the datastreams.
   if (file_exists($filePath)) {

--- a/islandora_bagit_extension.module
+++ b/islandora_bagit_extension.module
@@ -91,6 +91,7 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
   } else {
 
     // disable cache to save memery for 5GB files
+    // ToDo: investigate usage of `file_transfer`
     drupal_page_is_cacheable(FALSE);
     if (ob_get_level()) {
       ob_end_clean();
@@ -108,16 +109,24 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
     header('Content-Length: ' . $fileSize);
 
     // Transfer file in 1024 byte chunks to save memory usage.
-    if ($fd = fopen($filePath, 'rb')) {
-      while (!feof($fd)) {
-        print fread($fd, 1024);
+    // ToDo: investigate usage of `file_transfer`
+    try {
+      if ($fd = fopen($filePath, 'rb')) {
+        while (!feof($fd)) {
+          print fread($fd, 1024);
+        }
+        fclose($fd);
       }
-      fclose($fd);
+      else {
+        http_response_code(404);
+      }
+    } 
+    catch (Exception $e) {
+      watchdog('bagit', 'BagIt Bag not created for !object: !mess.',
+        array('!object' => $object_to_bag_pid, '!mess' => $e->getMessage()));
+      http_response_code(500);
     }
-    else {
-      http_response_code(404);
-    }
-
+  
   // Clean up the temp directory where we downloaded the datastreams.
   if (file_exists($filePath)) {
     unlink($filePath);

--- a/islandora_bagit_extension.module
+++ b/islandora_bagit_extension.module
@@ -126,7 +126,8 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
         array('!object' => $object_to_bag_pid, '!mess' => $e->getMessage()));
       http_response_code(500);
     }
-  
+  }
+
   // Clean up the temp directory where we downloaded the datastreams.
   if (file_exists($filePath)) {
     unlink($filePath);


### PR DESCRIPTION
- fixes error reporting
- disables cache and chunks files to avoid memory exhaustion error on 4.8GB files

e.g. 
[Sat Jan 26 06:24:41.105326 2019] [:error] [pid 3683] [client 129.128.217.75:45748] PHP Fatal error:  Allowed memory size of 7717519360 bytes exhausted (tried to allocate 5190430720 bytes) in /var/www/sites/beta.cwrc.ca/includes/common.inc on line 2780