### PR TITLE
address #3 header warning

### DIFF
--- a/islandora_bagit_extension.module
+++ b/islandora_bagit_extension.module
@@ -133,6 +133,7 @@ function islandora_bagit_extension_return_bag($object_to_bag_pid) {
     unlink($filePath);
   }
 
+  drupal_exit();
 }
 
 /**


### PR DESCRIPTION
Address header warning with `drupal_exit()`